### PR TITLE
feat custom prompt category

### DIFF
--- a/src/app/api/generate-flashcards/route.ts
+++ b/src/app/api/generate-flashcards/route.ts
@@ -7,7 +7,7 @@ const openai = new OpenAI({
 
 export async function POST(req: Request) {
   try {
-    const { count } = await req.json();
+    const { count, message } = await req.json();
 
     if (!count || count <= 0) {
       return NextResponse.json(
@@ -18,6 +18,11 @@ export async function POST(req: Request) {
 
     const prompt = `
       Wygeneruj ${count} fiszek do nauki angielskiego w formacie JSON.
+      Fiszki powinny bazować na podanym przez użytkownika zdaniu: ${message}.
+      Zdanie to może być np 'rozmowa rekrutacyjna' co oznacza, że fiszki powinny zawierać słowa związane z rozmową rekrutacyjną. Jej przebiegiem w korporacji. 
+      Jeśli na przykład user wpisze 'zamawianie jedzenia' / 'wizyta w restauracji' to również fiszki powinny być związane z tematyką restauracji, jedzenia, zamawiania jedzenia.
+      Chodzi kontakst, żeby fiszki były związane z tematem zdania.
+        
       Każda fiszka powinna zawierać:
       - "origin_text": słowo lub frazę po angielsku
       - "translate_text": tłumaczenie na język polski

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 
 export default function Home() {
   const [flashcards, setFlashcards] = useState<
@@ -9,6 +10,7 @@ export default function Home() {
   >([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [promptMessage, setPromptMessage] = useState<string>("");
 
   const handleGenerate = async () => {
     setLoading(true);
@@ -18,7 +20,7 @@ export default function Home() {
       const response = await fetch("/api/generate-flashcards", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ count: 5 }),
+        body: JSON.stringify({ count: 5, message: promptMessage }),
       });
 
       if (!response.ok) throw new Error("Błąd pobierania fiszek");
@@ -40,6 +42,7 @@ export default function Home() {
   return (
     <div className="p-6 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold">Generator Fiszek</h1>
+      <Input onChange={(e) => setPromptMessage(e.target.value)} />
       <Button
         onClick={handleGenerate}
         disabled={loading}


### PR DESCRIPTION
Enhancement: Allow users to specify flashcard category in prompt

This update introduces the ability for users to input a custom category for flashcard generation. Added {message} to the OpenAI prompt, allowing dynamic category specification.

Implemented an Input component from shadcn/ui for user input.
This feature is still in TEST / DEV mode, and the prompt structure will be refined in the future.