### PR TITLE
Feat add flashcards route to handle user cards

### DIFF
--- a/data/flashcards_query_response.json
+++ b/data/flashcards_query_response.json
@@ -14,22 +14,26 @@
       {
         "origin_text": "kwalifikacje",
         "translate_text": "qualifications",
-        "example_using": "Can you tell us more about your qualifications for this position?"
+        "example_using": "Can you tell us more about your qualifications for this position?",
+        "category": "Job Interview"
       },
       {
         "origin_text": "doświadczenie",
         "translate_text": "experience",
-        "example_using": "I have five years of experience in project management."
+        "example_using": "I have five years of experience in project management.",
+        "category": "Job Interview"
       },
       {
         "origin_text": "mocne strony",
         "translate_text": "strengths",
-        "example_using": "One of my strengths is my ability to work under pressure."
+        "example_using": "One of my strengths is my ability to work under pressure.",
+        "category": "Job Interview"
       },
       {
         "origin_text": "słabe strony",
         "translate_text": "weaknesses",
-        "example_using": "My biggest weakness is that I sometimes take on too much responsibility."
+        "example_using": "My biggest weakness is that I sometimes take on too much responsibility.",
+        "category": "Job Interview"
       }
     ]
   },
@@ -48,17 +52,20 @@
       {
         "origin_text": "umowa wynajmu",
         "translate_text": "rental agreement",
-        "example_using": "Before driving away, make sure to read the rental agreement carefully."
+        "example_using": "Before driving away, make sure to read the rental agreement carefully.",
+        "category": "Car Rental"
       },
       {
         "origin_text": "ubezpieczenie",
         "translate_text": "insurance",
-        "example_using": "Check if your insurance coverage includes rental cars abroad."
+        "example_using": "Check if your insurance coverage includes rental cars abroad.",
+        "category": "Car Rental"
       },
       {
         "origin_text": "miejsce zwrotu",
         "translate_text": "drop-off location",
-        "example_using": "You can choose a different drop-off location for an additional fee."
+        "example_using": "You can choose a different drop-off location for an additional fee.",
+        "category": "Car Rental"
       }
     ]
   },
@@ -77,17 +84,20 @@
       {
         "origin_text": "zrównoważony rozwój",
         "translate_text": "sustainability",
-        "example_using": "Our ESG department focuses on sustainability to ensure long-term environmental health."
+        "example_using": "Our ESG department focuses on sustainability to ensure long-term environmental health.",
+        "category": "ESG Work"
       },
       {
         "origin_text": "ślad węglowy",
         "translate_text": "carbon footprint",
-        "example_using": "Reducing the carbon footprint is a key goal in our ESG strategy."
+        "example_using": "Reducing the carbon footprint is a key goal in our ESG strategy.",
+        "category": "ESG Work"
       },
       {
         "origin_text": "zaangażowanie interesariuszy",
         "translate_text": "stakeholder engagement",
-        "example_using": "Effective stakeholder engagement is crucial for the success of our ESG initiatives."
+        "example_using": "Effective stakeholder engagement is crucial for the success of our ESG initiatives.",
+        "category": "ESG Work"
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-progress": "^1.1.1",
+        "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-select": "^2.1.5",
         "@radix-ui/react-slot": "^1.1.1",
         "@types/canvasjs": "^1.9.11",
@@ -1165,6 +1166,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
@@ -1196,6 +1221,37 @@
       "dependencies": {
         "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.2.tgz",
+      "integrity": "sha512-EFI1N/S3YxZEW/lJ/H1jY3njlvTd8tBmgKEn4GHi51+aMm94i6NmAJstsm5cu3yJwYqYc93gpCPm21FeAbFk6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-progress": "^1.1.1",
+    "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-slot": "^1.1.1",
     "@types/canvasjs": "^1.9.11",

--- a/src/app/context/flashcards-context.tsx
+++ b/src/app/context/flashcards-context.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useState, useContext, ReactNode } from "react";
+import { FlashCard } from "@/lib/flashcard.schema";
+
+interface FlashcardsContextType {
+  flashcards: FlashCard[];
+  setFlashcards: (flashcards: FlashCard[]) => void;
+}
+
+const FlashcardsContext = createContext<FlashcardsContextType | undefined>(
+  undefined
+);
+
+export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
+  const [flashcards, setFlashcards] = useState<FlashCard[]>([]);
+
+  return (
+    <FlashcardsContext.Provider value={{ flashcards, setFlashcards }}>
+      {children}
+    </FlashcardsContext.Provider>
+  );
+};
+
+export const useFlashcards = () => {
+  const context = useContext(FlashcardsContext);
+  if (!context) {
+    throw new Error("useFlashcards must be used within a FlashcardsProvider");
+  }
+  return context;
+};

--- a/src/app/flashcards/page.tsx
+++ b/src/app/flashcards/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState, useEffect } from "react";
+// import { useRouter } from "next/navigation"
+import { FlashcardsSidebar } from "@/components/flashcards-sidebar";
+
+import { categories, sampleFlashcards } from "@/lib/sample-flashcards";
+import { Button } from "@/components/ui/button";
+import { Menu, Grid, Maximize2 } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { FlashcardView } from "@/components/flaschard-view";
+import { FlashcardGrid } from "@/components/flashcard-grid";
+
+export default function FlashcardsPage() {
+  //   const router = useRouter()
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [currentCardIndex, setCurrentCardIndex] = useState(0);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<"single" | "grid">("single");
+
+  // Get cards for selected category
+  const categoryCards = selectedCategory
+    ? sampleFlashcards.filter((card) => card.category === selectedCategory)
+    : [];
+
+  const currentCard = categoryCards[currentCardIndex];
+
+  useEffect(() => {
+    setCurrentCardIndex(0);
+  }, []);
+
+  const handleNext = (known: boolean) => {
+    console.log(
+      `Card ${currentCard.id} marked as ${known ? "known" : "unknown"}`
+    );
+    setCurrentCardIndex((prev) => (prev + 1) % categoryCards.length);
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <div className="flex">
+        {/* Mobile Menu Button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="md:hidden fixed top-4 left-4 z-50 text-white"
+          onClick={() => setIsMobileSidebarOpen(!isMobileSidebarOpen)}
+        >
+          <Menu className="h-6 w-6" />
+        </Button>
+
+        {/* Sidebar */}
+        <div
+          className={`
+          fixed inset-y-0 left-0 z-40 transform transition-transform duration-300 ease-in-out
+          md:relative md:transform-none
+          ${
+            isMobileSidebarOpen
+              ? "translate-x-0"
+              : "-translate-x-full md:translate-x-0"
+          }
+        `}
+        >
+          <FlashcardsSidebar
+            categories={categories}
+            selectedCategory={selectedCategory}
+            onSelectCategory={(category) => {
+              setSelectedCategory(category);
+              setIsMobileSidebarOpen(false);
+            }}
+            isCollapsed={isSidebarCollapsed}
+            onToggleCollapse={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+          />
+        </div>
+
+        {/* Backdrop */}
+        {isMobileSidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-30 md:hidden"
+            onClick={() => setIsMobileSidebarOpen(false)}
+          />
+        )}
+
+        {/* Main Content */}
+        <main className="flex-1 p-4 sm:p-8 pt-20 md:pt-8">
+          {selectedCategory ? (
+            <>
+              {/* View Toggle */}
+              <div className="flex justify-end mb-6">
+                <div className="bg-black/40 backdrop-blur-sm border border-white/10 rounded-lg p-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`text-white hover:bg-purple-500/20 transition-colors ${
+                      viewMode === "single" ? "bg-purple-500/20" : ""
+                    }`}
+                    onClick={() => setViewMode("single")}
+                  >
+                    <Maximize2 className="h-5 w-5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`text-white hover:bg-purple-500/20 transition-colors ${
+                      viewMode === "grid" ? "bg-purple-500/20" : ""
+                    }`}
+                    onClick={() => setViewMode("grid")}
+                  >
+                    <Grid className="h-5 w-5" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* Content */}
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={viewMode}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {viewMode === "single" ? (
+                    currentCard ? (
+                      <FlashcardView card={currentCard} onNext={handleNext} />
+                    ) : (
+                      <div className="flex items-center justify-center h-[calc(100vh-12rem)]">
+                        <p className="text-gray-400">
+                          No flashcards available for this category.
+                        </p>
+                      </div>
+                    )
+                  ) : (
+                    <FlashcardGrid cards={categoryCards} />
+                  )}
+                </motion.div>
+              </AnimatePresence>
+            </>
+          ) : (
+            <div className="flex items-center justify-center h-[calc(100vh-12rem)]">
+              <p className="text-gray-400">
+                Select a category to start learning.
+              </p>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/flashcards/page.tsx
+++ b/src/app/flashcards/page.tsx
@@ -4,12 +4,12 @@ import { useState, useEffect } from "react";
 // import { useRouter } from "next/navigation"
 import { FlashcardsSidebar } from "@/components/flashcards-sidebar";
 
-import { categories, sampleFlashcards } from "@/lib/sample-flashcards";
 import { Button } from "@/components/ui/button";
 import { Menu, Grid, Maximize2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { FlashcardView } from "@/components/flaschard-view";
 import { FlashcardGrid } from "@/components/flashcard-grid";
+import { useFlashcards } from "../context/flashcards-context";
 
 export default function FlashcardsPage() {
   //   const router = useRouter()
@@ -19,12 +19,14 @@ export default function FlashcardsPage() {
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"single" | "grid">("single");
 
+  const { flashcards } = useFlashcards();
+
   // Get cards for selected category
   const categoryCards = selectedCategory
-    ? sampleFlashcards.filter((card) => card.category === selectedCategory)
+    ? flashcards.filter((card) => card.category === selectedCategory)
     : [];
 
-  const currentCard = categoryCards[currentCardIndex];
+  const currentCard = categoryCards[currentCardIndex] ?? null;
 
   useEffect(() => {
     setCurrentCardIndex(0);
@@ -32,7 +34,7 @@ export default function FlashcardsPage() {
 
   const handleNext = (known: boolean) => {
     console.log(
-      `Card ${currentCard.id} marked as ${known ? "known" : "unknown"}`
+      `Card ${currentCardIndex} marked as ${known ? "known" : "unknown"}`
     );
     setCurrentCardIndex((prev) => (prev + 1) % categoryCards.length);
   };
@@ -63,7 +65,6 @@ export default function FlashcardsPage() {
         `}
         >
           <FlashcardsSidebar
-            categories={categories}
             selectedCategory={selectedCategory}
             onSelectCategory={(category) => {
               setSelectedCategory(category);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { FlashcardsProvider } from "./context/flashcards-context";
 import "./globals.css";
 
 export default function RootLayout({
@@ -7,7 +8,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <FlashcardsProvider> {children}</FlashcardsProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/flaschard-view.tsx
+++ b/src/components/flaschard-view.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { ThumbsUp, ThumbsDown, Volume2 } from "lucide-react";
+import type { Flashcard } from "@/lib/sample-flashcards";
+import { useState } from "react";
+
+interface FlashcardViewProps {
+  card: Flashcard;
+  onNext: (known: boolean) => void;
+}
+
+export function FlashcardView({ card, onNext }: FlashcardViewProps) {
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 p-4 w-full max-w-2xl mx-auto">
+      {/* Card */}
+      <div
+        className="w-full aspect-[3/2] relative cursor-pointer [perspective:1000px] group"
+        onClick={() => setIsFlipped(!isFlipped)}
+      >
+        {/* Card glow effect */}
+        <div className="absolute -inset-1 bg-gradient-to-r from-purple-500 to-pink-500 rounded-xl opacity-0 group-hover:opacity-30 blur-xl transition-opacity duration-500" />
+
+        <motion.div
+          className="w-full h-full relative [transform-style:preserve-3d] transition-transform duration-150"
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+        >
+          {/* Front */}
+          <div className="absolute inset-0 w-full h-full [backface-visibility:hidden]">
+            <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-8 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
+              <div className="flex-1 flex flex-col items-center justify-center text-center gap-6">
+                <h2 className="text-4xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80 mb-2">
+                  {card.front.word}
+                </h2>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-400 text-lg">
+                    {card.front.phonetic}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-purple-400 hover:text-purple-300 hover:bg-purple-500/20 transition-colors"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      // Add pronunciation logic here
+                    }}
+                  >
+                    <Volume2 className="h-5 w-5" />
+                  </Button>
+                </div>
+                <div className="text-gray-300 text-center italic text-sm sm:text-base max-w-md">
+                  &quot;{card.front.example}&quot;
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Back */}
+          <div className="absolute inset-0 w-full h-full [backface-visibility:hidden] [transform:rotateY(180deg)]">
+            <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-8 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
+              <div className="flex-1 flex flex-col items-center justify-center text-center gap-6">
+                <h2 className="text-4xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80 mb-2">
+                  {card.back.translation}
+                </h2>
+                <div className="text-gray-300 text-center italic text-sm sm:text-base max-w-md">
+                  &quot;{card.back.example}&quot;
+                </div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex gap-4 w-full max-w-md mx-auto">
+        <Button
+          size="lg"
+          className="flex-1 bg-black/40 backdrop-blur-sm hover:bg-red-500/20 text-white border-2 border-red-500/30 hover:border-red-500 transition-all duration-300 relative group overflow-hidden hover:shadow-lg hover:shadow-red-500/20"
+          onClick={() => onNext(false)}
+        >
+          <span className="relative flex items-center gap-2">
+            <ThumbsDown className="h-5 w-5" />I can&apos;t
+          </span>
+          <div className="absolute inset-0 bg-gradient-to-r from-red-500/0 via-red-500/20 to-red-500/0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        </Button>
+        <Button
+          size="lg"
+          className="flex-1 bg-black/40 backdrop-blur-sm hover:bg-green-500/20 text-white border-2 border-green-500/30 hover:border-green-500 transition-all duration-300 relative group overflow-hidden hover:shadow-lg hover:shadow-green-500/20"
+          onClick={() => onNext(true)}
+        >
+          <span className="relative flex items-center gap-2">
+            <ThumbsUp className="h-5 w-5" />I can
+          </span>
+          <div className="absolute inset-0 bg-gradient-to-r from-green-500/0 via-green-500/20 to-green-500/0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/flaschard-view.tsx
+++ b/src/components/flaschard-view.tsx
@@ -2,12 +2,12 @@
 
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
-import { ThumbsUp, ThumbsDown, Volume2 } from "lucide-react";
-import type { Flashcard } from "@/lib/sample-flashcards";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
 import { useState } from "react";
+import type { FlashCard } from "@/lib/flashcard.schema";
 
 interface FlashcardViewProps {
-  card: Flashcard;
+  card: FlashCard;
   onNext: (known: boolean) => void;
 }
 
@@ -33,26 +33,10 @@ export function FlashcardView({ card, onNext }: FlashcardViewProps) {
             <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-8 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
               <div className="flex-1 flex flex-col items-center justify-center text-center gap-6">
                 <h2 className="text-4xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80 mb-2">
-                  {card.front.word}
+                  {card.origin_text}
                 </h2>
-                <div className="flex items-center gap-2">
-                  <span className="text-gray-400 text-lg">
-                    {card.front.phonetic}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="text-purple-400 hover:text-purple-300 hover:bg-purple-500/20 transition-colors"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      // Add pronunciation logic here
-                    }}
-                  >
-                    <Volume2 className="h-5 w-5" />
-                  </Button>
-                </div>
                 <div className="text-gray-300 text-center italic text-sm sm:text-base max-w-md">
-                  &quot;{card.front.example}&quot;
+                  &quot;{card.example_using}&quot;
                 </div>
               </div>
             </div>
@@ -63,17 +47,16 @@ export function FlashcardView({ card, onNext }: FlashcardViewProps) {
             <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-8 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
               <div className="flex-1 flex flex-col items-center justify-center text-center gap-6">
                 <h2 className="text-4xl sm:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80 mb-2">
-                  {card.back.translation}
+                  {card.translate_text}
                 </h2>
                 <div className="text-gray-300 text-center italic text-sm sm:text-base max-w-md">
-                  &quot;{card.back.example}&quot;
+                  &quot;{card.example_using}&quot;
                 </div>
               </div>
             </div>
           </div>
         </motion.div>
       </div>
-
       {/* Action Buttons */}
       <div className="flex gap-4 w-full max-w-md mx-auto">
         <Button

--- a/src/components/flashcard-grid.tsx
+++ b/src/components/flashcard-grid.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { Volume2 } from "lucide-react";
+import type { Flashcard } from "@/lib/sample-flashcards";
+import { useState } from "react";
+
+interface FlashcardGridProps {
+  cards: Flashcard[];
+}
+
+export function FlashcardGrid({ cards }: FlashcardGridProps) {
+  const [flippedCards, setFlippedCards] = useState<Record<string, boolean>>({});
+
+  const toggleCard = (cardId: string) => {
+    setFlippedCards((prev) => ({
+      ...prev,
+      [cardId]: !prev[cardId],
+    }));
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 p-4">
+      {cards.map((card, index) => (
+        <motion.div
+          key={card.id}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: index * 0.1 }}
+          className="aspect-[3/2] relative cursor-pointer [perspective:1000px] group"
+          onClick={() => toggleCard(card.id)}
+        >
+          {/* Card glow effect */}
+          <div className="absolute -inset-1 bg-gradient-to-r from-purple-500 to-pink-500 rounded-xl opacity-0 group-hover:opacity-30 blur-xl transition-opacity duration-500" />
+
+          <motion.div
+            className="w-full h-full relative [transform-style:preserve-3d] transition-transform duration-150"
+            animate={{ rotateY: flippedCards[card.id] ? 180 : 0 }}
+          >
+            {/* Front */}
+            <div className="absolute inset-0 w-full h-full [backface-visibility:hidden]">
+              <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-6 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
+                <div className="flex-1 flex flex-col items-center justify-center text-center gap-4">
+                  <h3 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80">
+                    {card.front.word}
+                  </h3>
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-400 text-sm">
+                      {card.front.phonetic}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-purple-400 hover:text-purple-300 hover:bg-purple-500/20 transition-colors"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        // Add pronunciation logic here
+                      }}
+                    >
+                      <Volume2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="text-gray-300 text-center italic text-sm line-clamp-2">
+                    &quot;{card.front.example}&quot;
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Back */}
+            <div className="absolute inset-0 w-full h-full [backface-visibility:hidden] [transform:rotateY(180deg)]">
+              <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-6 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
+                <div className="flex-1 flex flex-col items-center justify-center text-center gap-4">
+                  <h3 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80">
+                    {card.back.translation}
+                  </h3>
+                  <div className="text-gray-300 text-center italic text-sm line-clamp-2">
+                    &quot;{card.back.example}&quot;
+                  </div>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/flashcard-grid.tsx
+++ b/src/components/flashcard-grid.tsx
@@ -1,22 +1,22 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Volume2 } from "lucide-react";
-import type { Flashcard } from "@/lib/sample-flashcards";
-import { useState } from "react";
+import type { FlashCard } from "@/lib/flashcard.schema";
 
 interface FlashcardGridProps {
-  cards: Flashcard[];
+  cards: FlashCard[];
 }
 
 export function FlashcardGrid({ cards }: FlashcardGridProps) {
-  const [flippedCards, setFlippedCards] = useState<Record<string, boolean>>({});
+  const [flippedCards, setFlippedCards] = useState<Record<number, boolean>>({});
 
-  const toggleCard = (cardId: string) => {
+  const toggleCard = (index: number) => {
     setFlippedCards((prev) => ({
       ...prev,
-      [cardId]: !prev[cardId],
+      [index]: !prev[index],
     }));
   };
 
@@ -24,45 +24,40 @@ export function FlashcardGrid({ cards }: FlashcardGridProps) {
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 p-4">
       {cards.map((card, index) => (
         <motion.div
-          key={card.id}
+          key={index}
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: index * 0.1 }}
           className="aspect-[3/2] relative cursor-pointer [perspective:1000px] group"
-          onClick={() => toggleCard(card.id)}
+          onClick={() => toggleCard(index)}
         >
           {/* Card glow effect */}
           <div className="absolute -inset-1 bg-gradient-to-r from-purple-500 to-pink-500 rounded-xl opacity-0 group-hover:opacity-30 blur-xl transition-opacity duration-500" />
 
           <motion.div
             className="w-full h-full relative [transform-style:preserve-3d] transition-transform duration-150"
-            animate={{ rotateY: flippedCards[card.id] ? 180 : 0 }}
+            animate={{ rotateY: flippedCards[index] ? 180 : 0 }}
           >
             {/* Front */}
             <div className="absolute inset-0 w-full h-full [backface-visibility:hidden]">
               <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-6 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
                 <div className="flex-1 flex flex-col items-center justify-center text-center gap-4">
                   <h3 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80">
-                    {card.front.word}
+                    {card.origin_text}
                   </h3>
-                  <div className="flex items-center gap-2">
-                    <span className="text-gray-400 text-sm">
-                      {card.front.phonetic}
-                    </span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="text-purple-400 hover:text-purple-300 hover:bg-purple-500/20 transition-colors"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        // Add pronunciation logic here
-                      }}
-                    >
-                      <Volume2 className="h-4 w-4" />
-                    </Button>
-                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-purple-400 hover:text-purple-300 hover:bg-purple-500/20 transition-colors"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      // Add pronunciation logic here (TTS API)
+                    }}
+                  >
+                    <Volume2 className="h-4 w-4" />
+                  </Button>
                   <div className="text-gray-300 text-center italic text-sm line-clamp-2">
-                    &quot;{card.front.example}&quot;
+                    &quot;{card.example_using}&quot;
                   </div>
                 </div>
               </div>
@@ -73,10 +68,10 @@ export function FlashcardGrid({ cards }: FlashcardGridProps) {
               <div className="h-full bg-black/40 backdrop-blur-md rounded-xl border border-white/10 p-6 flex flex-col group hover:border-purple-500/50 transition-all duration-300 hover:bg-black/50 hover:shadow-2xl">
                 <div className="flex-1 flex flex-col items-center justify-center text-center gap-4">
                   <h3 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-br from-white to-white/80">
-                    {card.back.translation}
+                    {card.translate_text}
                   </h3>
                   <div className="text-gray-300 text-center italic text-sm line-clamp-2">
-                    &quot;{card.back.example}&quot;
+                    &quot;{card.example_using}&quot;
                   </div>
                 </div>
               </div>

--- a/src/components/flashcards-sidebar.tsx
+++ b/src/components/flashcards-sidebar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface FlashcardsSidebarProps {
+  categories: string[];
+  selectedCategory: string | null;
+  onSelectCategory: (category: string) => void;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+}
+
+export function FlashcardsSidebar({
+  categories,
+  selectedCategory,
+  onSelectCategory,
+  isCollapsed,
+  onToggleCollapse,
+}: FlashcardsSidebarProps) {
+  return (
+    <div className="relative h-screen">
+      <motion.div
+        className={cn(
+          "h-full bg-black/40 backdrop-blur-md border-r border-white/10",
+          isCollapsed ? "w-[60px]" : "w-[240px]"
+        )}
+        animate={{ width: isCollapsed ? 60 : 240 }}
+        transition={{ duration: 0.2 }}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-white/10 bg-black/20">
+          {!isCollapsed && (
+            <motion.h2
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="text-lg font-semibold text-transparent bg-clip-text bg-gradient-to-r from-white to-white/70"
+            >
+              Categories
+            </motion.h2>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onToggleCollapse}
+            className="text-white hover:bg-purple-500/20 transition-all duration-300 hover:text-purple-400 hidden md:flex"
+          >
+            {isCollapsed ? (
+              <ChevronRight className="h-5 w-5" />
+            ) : (
+              <ChevronLeft className="h-5 w-5" />
+            )}
+          </Button>
+        </div>
+
+        <ScrollArea className="h-[calc(100vh-4rem)]">
+          <div className="p-2 space-y-1">
+            {categories.map((category) => (
+              <Button
+                key={category}
+                variant="ghost"
+                className={cn(
+                  "w-full justify-start mb-1 relative group overflow-hidden transition-all duration-300",
+                  selectedCategory === category
+                    ? "bg-purple-500/20 text-white hover:bg-purple-500/30"
+                    : "text-gray-400 hover:text-white hover:bg-white/5"
+                )}
+                onClick={() => onSelectCategory(category)}
+              >
+                <span className="relative z-10">
+                  {isCollapsed ? category.charAt(0) : category}
+                </span>
+                {/* Active indicator */}
+                {selectedCategory === category && (
+                  <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-gradient-to-b from-purple-500 to-pink-500" />
+                )}
+                {/* Hover effect */}
+                <div className="absolute inset-0 bg-gradient-to-r from-purple-500/0 via-purple-500/10 to-pink-500/0 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </Button>
+            ))}
+          </div>
+        </ScrollArea>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/flashcards-sidebar.tsx
+++ b/src/components/flashcards-sidebar.tsx
@@ -5,9 +5,9 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useFlashcards } from "@/app/context/flashcards-context";
 
 interface FlashcardsSidebarProps {
-  categories: string[];
   selectedCategory: string | null;
   onSelectCategory: (category: string) => void;
   isCollapsed: boolean;
@@ -15,12 +15,16 @@ interface FlashcardsSidebarProps {
 }
 
 export function FlashcardsSidebar({
-  categories,
   selectedCategory,
   onSelectCategory,
   isCollapsed,
   onToggleCollapse,
 }: FlashcardsSidebarProps) {
+  const { flashcards } = useFlashcards();
+
+  // Pobierz unikalne kategorie z fiszek
+  const categories = [...new Set(flashcards.map((card) => card.category))];
+
   return (
     <div className="relative h-screen">
       <motion.div
@@ -57,29 +61,35 @@ export function FlashcardsSidebar({
 
         <ScrollArea className="h-[calc(100vh-4rem)]">
           <div className="p-2 space-y-1">
-            {categories.map((category) => (
-              <Button
-                key={category}
-                variant="ghost"
-                className={cn(
-                  "w-full justify-start mb-1 relative group overflow-hidden transition-all duration-300",
-                  selectedCategory === category
-                    ? "bg-purple-500/20 text-white hover:bg-purple-500/30"
-                    : "text-gray-400 hover:text-white hover:bg-white/5"
-                )}
-                onClick={() => onSelectCategory(category)}
-              >
-                <span className="relative z-10">
-                  {isCollapsed ? category.charAt(0) : category}
-                </span>
-                {/* Active indicator */}
-                {selectedCategory === category && (
-                  <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-gradient-to-b from-purple-500 to-pink-500" />
-                )}
-                {/* Hover effect */}
-                <div className="absolute inset-0 bg-gradient-to-r from-purple-500/0 via-purple-500/10 to-pink-500/0 opacity-0 group-hover:opacity-100 transition-opacity" />
-              </Button>
-            ))}
+            {categories.length > 0 ? (
+              categories.map((category) => (
+                <Button
+                  key={category}
+                  variant="ghost"
+                  className={cn(
+                    "w-full justify-start mb-1 relative group overflow-hidden transition-all duration-300",
+                    selectedCategory === category
+                      ? "bg-purple-500/20 text-white hover:bg-purple-500/30"
+                      : "text-gray-400 hover:text-white hover:bg-white/5"
+                  )}
+                  onClick={() => onSelectCategory(category)}
+                >
+                  <span className="relative z-10">
+                    {isCollapsed ? category.charAt(0) : category}
+                  </span>
+                  {/* Active indicator */}
+                  {selectedCategory === category && (
+                    <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-gradient-to-b from-purple-500 to-pink-500" />
+                  )}
+                  {/* Hover effect */}
+                  <div className="absolute inset-0 bg-gradient-to-r from-purple-500/0 via-purple-500/10 to-pink-500/0 opacity-0 group-hover:opacity-100 transition-opacity" />
+                </Button>
+              ))
+            ) : (
+              <p className="text-gray-400 text-center py-4">
+                No categories available
+              </p>
+            )}
           </div>
         </ScrollArea>
       </motion.div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -8,8 +8,8 @@ import { AnimatedInput } from "@/components/animated-input";
 import { Categories } from "@/components/categories";
 import { useState } from "react";
 import { Loader } from "@/components/ui/loader";
-// import { useRouter } from "next/navigation";
-import { FloatingFlashcards } from "./floating.flashcards";
+import { useRouter } from "next/navigation";
+// import { FloatingFlashcards } from "./floating.flashcards";
 import { FlashCard } from "@/lib/flashcard.schema";
 
 export default function Hero() {
@@ -18,7 +18,7 @@ export default function Hero() {
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [userInput, setUserInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  //   const router = useRouter();
+  const router = useRouter();
 
   const handleGenerateFlashcards = async () => {
     if (!userInput.trim()) return;
@@ -28,7 +28,7 @@ export default function Hero() {
       const response = await fetch("/api/generate-flashcards", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ count: 10, message: userInput }),
+        body: JSON.stringify({ count: 5, message: userInput }),
       });
 
       if (!response.ok) throw new Error("Błąd pobierania fiszek");
@@ -38,7 +38,7 @@ export default function Hero() {
       setUserInput("");
       console.log("Wygenerowane fiszki:", data);
       // Navigate to flashcards page
-      //   router.push("/flashcards");
+      router.push("/flashcards");
     } catch (error) {
       console.error("Failed to generate flashcards:", error);
       setIsLoading(false);
@@ -55,9 +55,9 @@ export default function Hero() {
       {isLoading && <Loader />}
 
       {/* Floating flashcards background */}
-      <div className="absolute inset-0 overflow-hidden">
+      {/* <div className="absolute inset-0 overflow-hidden">
         <FloatingFlashcards />
-      </div>
+      </div> */}
 
       <div className="container mx-auto px-6 relative z-10">
         <div className="max-w-4xl mx-auto text-center">

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -10,10 +10,13 @@ import { useState } from "react";
 import { Loader } from "@/components/ui/loader";
 import { useRouter } from "next/navigation";
 // import { FloatingFlashcards } from "./floating.flashcards";
-import { FlashCard } from "@/lib/flashcard.schema";
+// import { FlashCard } from "@/lib/flashcard.schema";
+import { useFlashcards } from "@/app/context/flashcards-context";
 
 export default function Hero() {
-  const [flashcards, setFlashcards] = useState<FlashCard[]>([]);
+  const { setFlashcards } = useFlashcards();
+
+  // const [flashcards, setFlashcards] = useState<FlashCard[]>([]);
 
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [userInput, setUserInput] = useState("");
@@ -47,7 +50,7 @@ export default function Hero() {
     }
   };
 
-  console.log(flashcards);
+  // console.log(flashcards);
 
   return (
     <div className="relative min-h-[calc(100vh-76px)] flex items-center">

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/src/lib/flashcard.schema.ts
+++ b/src/lib/flashcard.schema.ts
@@ -4,6 +4,7 @@ export const ResponsStructure = z.object({
   origin_text: z.string(),
   translate_text: z.string(),
   example_using: z.string(),
+  category: z.string(),
 });
 
 export const FlashCardSchema = z.object({

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -20,36 +20,42 @@ export const getFlashcardsPrompt = (
 
   return `
   Generate ${count} unique and diverse flashcards for learning English in **valid JSON format** based on the following topic or description:
-  ""${message}. The difficulty of the flashcards should be appropriate for the ${level} level of English."
+  **"${message}".** The difficulty of the flashcards should be appropriate for the **${level}** level of English.
 
-
-
-  
   ### **Guidelines:**
-  1. **Flashcards must be strictly relevant** to the given topic or description. Whether it is a general category (e.g., "vacation") or a detailed scenario (e.g., "I have a job interview at a food corporation"), the flashcards should focus only on words and phrases directly useful in that context.
+  1. **Flashcards must be strictly relevant** to the given topic or description.
   2. **Each flashcard must include:**
      - **"origin_text"**: A word or phrase in English.
      - **"translate_text"**: The Polish translation.
      - **"example_using"**: A sample sentence demonstrating the word/phrase in a real-world context related to the provided topic.
+     - **"category"**: A short, meaningful category that represents the key theme of the flashcard (e.g., "Job Interview", "Car Rental", "ESG Work"). A single, consistent category that applies to **all** generated flashcards.
   3. **Ensure the following:**
      - Words and phrases are **unique** (no repetitions).
      - Example sentences are **diverse** and **practical for real-world use**.
      - Avoid **overly simple, obvious, or off-topic words** that do not directly aid in learning the topic effectively.
   4. **The response must be in strict JSON format, following this exact structure, with no additional text or comments:**
-  
+
   \`\`\`json
   {
     "flashcards": [
       {
         "origin_text": "example word",
         "translate_text": "example translation",
-        "example_using": "example sentence using the word in context"
+        "example_using": "example sentence using the word in context",
+        "category": "example category"
       }
     ]
   }
   \`\`\`
 
-      ### **Reference Previous Examples:**
+### **Category Guidelines:**
+  - The category should be **concise and descriptive**, summarizing the primary theme of the flashcards.
+  - **All generated flashcards must belong to the same category** (no mixing within one response).
+  - Choose a category that accurately reflects the user's input. 
+  - If the user's input is broad (e.g., "travel"), use a meaningful subcategory such as "Airport", "Hotel Booking", or "Local Transport".
+  - If uncertain, choose the most general but meaningful category.
+
+  ### **Reference Previous Examples:**
   The user has previously requested flashcards for similar topics. Here are some examples:
   ${
     previousExamples.length > 0
@@ -58,14 +64,15 @@ export const getFlashcardsPrompt = (
   }
   
   ### **Incorrect Example (for the topic "Job Interview")**
-  - Words should help in **handling** the interview (e.g., "experience", "qualifications", "competency-based questions"), not **unrelated terms** (e.g., "professional attire", which is about dressing rather than the conversation itself).
+  - Words should help in **handling** the interview (e.g., "experience", "qualifications"), not **general terms** (e.g., "business etiquette").
   \`\`\`json
   {
     "flashcards": [
       {
-        "origin_text": "professional attire",
-        "translate_text": "profesjonalny strój",
-        "example_using": "Wearing professional attire is crucial for making a good impression at a corporate interview."
+        "origin_text": "business etiquette",
+        "translate_text": "etykieta biznesowa",
+        "example_using": "Proper business etiquette helps maintain professional relationships.",
+        "category": "Incorrect"
       }
     ]
   }
@@ -79,13 +86,11 @@ export const getFlashcardsPrompt = (
       {
         "origin_text": "rental agreement",
         "translate_text": "umowa wynajmu",
-        "example_using": "Before driving away, make sure to read the rental agreement carefully."
+        "example_using": "Before driving away, make sure to read the rental agreement carefully.",
+        "category": "Car Rental"
       }
     ]
   }
-    
   \`\`\`
-
-
-    `;
+  `;
 };

--- a/src/lib/sample-flashcards.ts
+++ b/src/lib/sample-flashcards.ts
@@ -1,0 +1,72 @@
+export type Flashcard = {
+  id: string;
+  category: string;
+  front: {
+    word: string;
+    phonetic: string;
+    example: string;
+  };
+  back: {
+    translation: string;
+    example: string;
+  };
+};
+
+export const sampleFlashcards: Flashcard[] = [
+  {
+    id: "1",
+    category: "Business",
+    front: {
+      word: "Spotkanie",
+      phonetic: "/spɔtˈkaɲɛ/",
+      example: "Mam ważne spotkanie z klientem.",
+    },
+    back: {
+      translation: "Meeting",
+      example: "I have an important meeting with a client.",
+    },
+  },
+  {
+    id: "2",
+    category: "Business",
+    front: {
+      word: "Prezentacja",
+      phonetic: "/prɛzɛnˈtat͡sja/",
+      example: "Przygotowałem prezentację na jutro.",
+    },
+    back: {
+      translation: "Presentation",
+      example: "I prepared a presentation for tomorrow.",
+    },
+  },
+  {
+    id: "3",
+    category: "Travel",
+    front: {
+      word: "Lotnisko",
+      phonetic: "/lɔtˈɲiskɔ/",
+      example: "Muszę być na lotnisku dwie godziny przed odlotem.",
+    },
+    back: {
+      translation: "Airport",
+      example: "I need to be at the airport two hours before departure.",
+    },
+  },
+  {
+    id: "4",
+    category: "Travel",
+    front: {
+      word: "Bilet",
+      phonetic: "/ˈbʲilɛt/",
+      example: "Gdzie mogę kupić bilet na pociąg?",
+    },
+    back: {
+      translation: "Ticket",
+      example: "Where can I buy a train ticket?",
+    },
+  },
+];
+
+export const categories = Array.from(
+  new Set(sampleFlashcards.map((card) => card.category))
+);


### PR DESCRIPTION
Changes Introduced:
✅ Added new components for handling flashcard display:

FlashcardView.tsx (single card view)
FlashcardGrid.tsx (grid view of flashcards)
FlashcardsSidebar.tsx (category selection sidebar)
✅ Created a new route: /flashcards, which opens after generating flashcards on the landing page.

✅ Temporary solution: Flashcards are currently managed using React Context API, but this will be integrated with Prisma + OpenAI API in the future.

✅ Removed the floating flashcards effect from the landing page to improve UI aesthetics.

⚠ This feature is still in the testing phase and subject to further improvements.