### PR TITLE
fix: create new user for prisma database

### DIFF
--- a/src/app/flashcards/view.tsx
+++ b/src/app/flashcards/view.tsx
@@ -39,16 +39,16 @@ export default function FlashcardsView({ initialFlashcards, serverError, initial
   const { signOut } = useClerk();
   const router = useRouter();
 
-  // Inicjalizacja kategorii
+  // Inicjalizacja kategorii - tylko jeśli nie ma wybranej kategorii i nie ma kategorii w URL
   useEffect(() => {
     // Ustaw pierwszą kategorię jako domyślną jeśli nie wybrano żadnej
-    if (initialFlashcards.length > 0 && !selectedCategory) {
+    if (initialFlashcards.length > 0 && !selectedCategory && !categoryFromUrl) {
       const categories = [...new Set(initialFlashcards.map(card => card.category))];
       if (categories.length > 0) {
         setSelectedCategory(categories[0]);
       }
     }
-  }, [initialFlashcards, selectedCategory]);
+  }, [initialFlashcards, selectedCategory, categoryFromUrl]);
 
   // Reset indeksu karty przy zmianie kategorii
   useEffect(() => {

--- a/src/hooks/useFlashcards.ts
+++ b/src/hooks/useFlashcards.ts
@@ -35,8 +35,12 @@ export function useFlashcards(options: UseFlashcardsOptions = {}) {
     try {
       const result = await generateFlashcardsAction(params);
       
-      if (result.success) {
-        router.push(redirectUrl);
+      if (result.success && result.flashcards && result.flashcards.length > 0) {
+        // Pobierz kategorię z pierwszej wygenerowanej fiszki
+        const generatedCategory = result.flashcards[0].category;
+        
+        // Przekieruj do strony z fiszkami z parametrem kategorii
+        router.push(`${redirectUrl}?category=${encodeURIComponent(generatedCategory)}`);
         return { success: true };
       } else {
         setErrorMessage(result.error || "Nie udało się wygenerować fiszek");


### PR DESCRIPTION
Issue
Database User Creation Failure: The application wasn't creating records for new users in the Prisma database, causing errors when they attempted to generate flashcards. The upsertUser method in GenerateFlashcardsUseCase only detected missing users without actually creating them.
Incorrect Default Category Selection: After successfully generating flashcards, the app redirected users to the flashcards page but set the default category to the first available one instead of showing the newly generated category.
Solution
1. Modified upsertUser method to properly create new users in the database using Prisma Client
Updated the redirect logic in useFlashcards to include the newly generated category as a URL parameter
Enhanced FlashcardsView component to prioritize categories from URL parameters
These changes allow new users to successfully generate flashcards and immediately view their newly generated content without manually searching for the correct category in the sidebar.