### PR TITLE
feat: make translate_category required field from OpenAI

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,7 +14,7 @@ datasource db {
 }
 
 model User {
-  id                String      @id // ID z Clerk
+  id                String      @id // ID from Clerk
   email             String      @unique
   username          String?
   createdAt         DateTime    @default(now())
@@ -24,7 +24,7 @@ model User {
   learningStreak    Int         @default(0)
   lastActivityDate  DateTime?
   preferredLanguage String      @default("en")
-  dailyGoal         Int         @default(10) // Liczba fiszek do nauki dziennie
+  dailyGoal         Int         @default(10) // Number of flashcards to learn daily
   level             Int         @default(1)
   experiencePoints  Int         @default(0)
 }
@@ -36,9 +36,10 @@ model Flashcard {
   example_using     String
   translate_example String
   category          String
-  sourceLanguage    String   @default("en") // Język źródłowy
-  targetLanguage    String   @default("pl") // Język docelowy
-  difficultyLevel   String   @default("easy") // Poziom trudności: easy, advanced, pro
+  translate_category String? // Category translation for user interface language
+  sourceLanguage    String   @default("en") // Source language
+  targetLanguage    String   @default("pl") // Target language
+  difficultyLevel   String   @default("easy") // Difficulty level: easy, advanced, pro
   createdAt         DateTime @default(now())
   user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId            String
@@ -55,7 +56,7 @@ model Progress {
   incorrectAnswers  Int       @default(0)
   lastReviewed      DateTime?
   nextReviewDate    DateTime?
-  masteryLevel      Int       @default(0) // 0-5 poziom opanowania
+  masteryLevel      Int       @default(0) // 0-5 mastery level
   
   @@unique([flashcardId, userId])
 }

--- a/src/app/actions/flashcard-actions.ts
+++ b/src/app/actions/flashcard-actions.ts
@@ -199,7 +199,7 @@ export async function importGuestFlashcardsAction(
       }
     }
 
-    // Teraz gdy mamy pewność, że użytkownik istnieje, importujemy fiszki
+    // Now that we're sure the user exists, import flashcards
     const flashcardRepository = getFlashcardRepository();
 
     const flashcardPromises = flashcards.map((card) =>
@@ -209,6 +209,7 @@ export async function importGuestFlashcardsAction(
         example_using: card.example_using,
         translate_example: card.translate_example,
         category: card.category,
+        translate_category: card.translate_category,
         sourceLanguage: card.sourceLanguage,
         targetLanguage: card.targetLanguage,
         difficultyLevel: card.difficultyLevel,
@@ -261,6 +262,7 @@ export async function handleGuestFlashcardGeneration(data: {
         example_using: flashcard.example_using || "",
         translate_example: flashcard.translate_example || "",
         category: flashcard.category || "",
+        translate_category: flashcard.translate_category,
         sourceLanguage: data.sourceLanguage,
         targetLanguage: data.targetLanguage,
         difficultyLevel: data.level,

--- a/src/app/actions/progress-actions.ts
+++ b/src/app/actions/progress-actions.ts
@@ -279,7 +279,7 @@ export async function updateDailyGoalAction(newGoal: number) {
   }
 }
 
-// Funkcja zwracająca kategorie gdzie wszystkie fiszki są już opanowane
+// Function returning categories where all flashcards are already mastered
 export async function getMasteredCategoriesAction() {
   try {
     // Check if in demo mode - if so, calculate from real flashcards + localStorage
@@ -297,7 +297,7 @@ export async function getMasteredCategoriesAction() {
       return { success: false, error: "Użytkownik nie jest zalogowany" };
     }
 
-    // Jedno zapytanie SQL, które znajdzie wszystkie opanowane kategorie
+    // Single SQL query that finds all mastered categories
     type CategoryResult = { category: string; total_count: bigint; mastered_count: bigint }[];
     
     const categoryStats = await prisma.$queryRaw<CategoryResult>`
@@ -319,7 +319,7 @@ export async function getMasteredCategoriesAction() {
       ORDER BY category
     `;
     
-    // Filtruj tylko kategorie, w których wszystkie fiszki są opanowane
+    // Filter only categories where all flashcards are mastered
     const masteredCategories = categoryStats
       .filter(({ total_count, mastered_count }) => 
         Number(total_count) > 0 && Number(total_count) === Number(mastered_count))

--- a/src/components/how-it-works.tsx
+++ b/src/components/how-it-works.tsx
@@ -232,18 +232,6 @@ export default function HowItWorks() {
                 <span>{t('step2.trackProgress')}</span>
               </li>
             </ul>
-
-            <div className="flex flex-wrap gap-3 mt-8">
-              <div className="inline-flex items-center px-6 py-2.5 rounded-full bg-black border border-pink-600 text-white">
-                {t('step2.nativeSpeaker')}
-              </div>
-              <div className="inline-flex items-center px-6 py-2.5 rounded-full bg-black border border-pink-600 text-white">
-                {t('step2.smartLearning')}
-              </div>
-              <div className="inline-flex items-center px-6 py-2.5 rounded-full bg-black border border-pink-600 text-white">
-                {t('step2.contextExamples')}
-              </div>
-            </div>
           </div>
         </motion.div>
 
@@ -286,18 +274,6 @@ export default function HowItWorks() {
                 </span>
               </li>
             </ul>
-
-            <div className="flex flex-wrap gap-3 mt-8">
-              <div className="inline-flex items-center px-6 py-2.5 rounded-full bg-black border border-purple-600 text-white">
-                {t('step3.progressAnalytics')}
-              </div>
-              <div className="inline-flex items-center px-6 py-2.5 rounded-full bg-black border border-purple-600 text-white">
-                {t('step3.customStudyPlans')}
-              </div>
-              <div className="inline-flex items-center px-6 py-2.5 rounded-full bg-black border border-purple-600 text-white">
-                {t('step3.crossDeviceSync')}
-              </div>
-            </div>
           </div>
 
           <div className="flex items-center justify-center">

--- a/src/core/entities/Flashcard.ts
+++ b/src/core/entities/Flashcard.ts
@@ -5,6 +5,7 @@ export interface Flashcard {
   example_using: string;
   translate_example: string;
   category: string;
+  translate_category: string;
   userId: string;
   sourceLanguage: string;
   targetLanguage: string;

--- a/src/core/useCases/flashcards/GenerateFlashcards.ts
+++ b/src/core/useCases/flashcards/GenerateFlashcards.ts
@@ -87,7 +87,7 @@ export class GenerateFlashcardsUseCase {
         };
       }
 
-      // Przypisz wybrane przez użytkownika ustawienia językowe do wygenerowanych fiszek
+      // Assign user-selected language settings to generated flashcards
       const flashcards = generatedFlashcards.map((flashcard) => ({
         ...flashcard,
         sourceLanguage,
@@ -160,7 +160,7 @@ export class GenerateFlashcardsUseCase {
           "flashcardResponse"
         ),
         temperature: 0.1,
-        max_tokens: 500,
+        max_tokens: 1000,
       });
 
       const parsedData = FlashCardSchema.parse(
@@ -205,6 +205,7 @@ export class GenerateFlashcardsUseCase {
         example_using: flashcard.example_using,
         translate_example: flashcard.translate_example,
         category: flashcard.category,
+        translate_category: flashcard.translate_category,
         sourceLanguage: flashcard.sourceLanguage,
         targetLanguage: flashcard.targetLanguage,
         difficultyLevel: flashcard.difficultyLevel,

--- a/src/lib/flashcard.schema.ts
+++ b/src/lib/flashcard.schema.ts
@@ -7,6 +7,7 @@ export const ResponsStructure = z.object({
   example_using: z.string(),
   translate_example: z.string(),
   category: z.string(),
+  translate_category: z.string(),
   sourceLanguage: z.string().optional(),
   targetLanguage: z.string().optional(),
   difficultyLevel: z.string().optional(),

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -5,142 +5,6 @@ export const getFlashcardsPrompt = (
   sourceLanguage: string = "en",
   targetLanguage: string = "pl"
 ) => {
-  // Przykłady fiszek zdefiniowane bezpośrednio w kodzie zamiast wczytywania z pliku
-  const previousExamples = [
-    {
-      "messages": [
-        {
-          "role": "system",
-          "content": "You are an expert language teacher who always provides high-quality, diverse, and contextually appropriate flashcards for language learning."
-        },
-        {
-          "role": "user",
-          "content": "Generate 3 flashcards about job interviews, level: intermediate"
-        }
-      ],
-      "response": [
-        {
-          "origin_text": "job interview",
-          "translate_text": "rozmowa kwalifikacyjna",
-          "example_using": "I have a job interview scheduled for tomorrow morning.",
-          "translate_example": "Mam zaplanowaną rozmowę kwalifikacyjną na jutro rano.",
-          "category": "Job Application",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "intermediate"
-        },
-        {
-          "origin_text": "resume",
-          "translate_text": "CV",
-          "example_using": "I updated my resume to include my recent work experience.",
-          "translate_example": "Zaktualizowałem moje CV, aby uwzględnić moje ostatnie doświadczenie zawodowe.",
-          "category": "Job Application",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "intermediate"
-        },
-        {
-          "origin_text": "qualifications",
-          "translate_text": "kwalifikacje",
-          "example_using": "The employer was impressed by my qualifications for the position.",
-          "translate_example": "Pracodawca był pod wrażeniem moich kwalifikacji na to stanowisko.",
-          "category": "Job Application",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "intermediate"
-        }
-      ]
-    },
-    {
-      "messages": [
-        {
-          "role": "system",
-          "content": "You are an expert language teacher who always provides high-quality, diverse, and contextually appropriate flashcards for language learning."
-        },
-        {
-          "role": "user",
-          "content": "I need 3 flashcards about car rental, level: beginner"
-        }
-      ],
-      "response": [
-        {
-          "origin_text": "rental agreement",
-          "translate_text": "umowa wynajmu",
-          "example_using": "Before driving away, make sure to read the rental agreement carefully.",
-          "translate_example": "Przed odjazdem upewnij się, że dokładnie przeczytałeś umowę wynajmu.",
-          "category": "Car Rental",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "beginner"
-        },
-        {
-          "origin_text": "insurance coverage",
-          "translate_text": "ochrona ubezpieczeniowa",
-          "example_using": "The insurance coverage for this rental car includes collision damage.",
-          "translate_example": "Ochrona ubezpieczeniowa tego wynajmowanego samochodu obejmuje uszkodzenia w wyniku kolizji.",
-          "category": "Car Rental",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "beginner"
-        },
-        {
-          "origin_text": "mileage limit",
-          "translate_text": "limit kilometrów",
-          "example_using": "There is a daily mileage limit of 200 kilometers for this rental.",
-          "translate_example": "Dla tego wynajmu obowiązuje dzienny limit kilometrów wynoszący 200 kilometrów.",
-          "category": "Car Rental",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "beginner"
-        }
-      ]
-    },
-    {
-      "messages": [
-        {
-          "role": "system",
-          "content": "You are an expert language teacher who always provides high-quality, diverse, and contextually appropriate flashcards for language learning."
-        },
-        {
-          "role": "user",
-          "content": "Create 3 business meeting vocabulary cards, level: advanced"
-        }
-      ],
-      "response": [
-        {
-          "origin_text": "agenda",
-          "translate_text": "porządek obrad",
-          "example_using": "Let's go through the agenda for today's meeting.",
-          "translate_example": "Przejdźmy przez porządek obrad dzisiejszego spotkania.",
-          "category": "Business Meeting",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "advanced"
-        },
-        {
-          "origin_text": "quarterly report",
-          "translate_text": "raport kwartalny",
-          "example_using": "We need to discuss the quarterly report during our next meeting.",
-          "translate_example": "Musimy omówić raport kwartalny podczas naszego następnego spotkania.",
-          "category": "Business Meeting",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "advanced"
-        },
-        {
-          "origin_text": "stakeholder",
-          "translate_text": "interesariusz",
-          "example_using": "All the key stakeholders will be attending tomorrow's presentation.",
-          "translate_example": "Wszyscy kluczowi interesariusze będą obecni na jutrzejszej prezentacji.",
-          "category": "Business Meeting",
-          "sourceLanguage": "en",
-          "targetLanguage": "pl",
-          "difficultyLevel": "advanced"
-        }
-      ]
-    }
-  ];
-
   const languageNames: Record<string, string> = {
     "en": "English",
     "pl": "Polish",
@@ -152,107 +16,33 @@ export const getFlashcardsPrompt = (
   const targetLang = languageNames[targetLanguage] || targetLanguage;
 
   return `
-  Generate ${count} unique and diverse flashcards for learning ${sourceLang} to ${targetLang} in **valid JSON format** based on the following topic or description:
-  **"${message}".** The difficulty of the flashcards should be appropriate for the **${level}** level of language learning.
+Generate ${count} flashcards for learning ${sourceLang} to ${targetLang}, topic: "${message}", level: ${level}.
 
-  ### **Guidelines:**
-  1. **Flashcards must be strictly relevant** to the given topic or description.
-  2. **Each flashcard must include:**
-     - **"origin_text"**: A word or phrase in ${sourceLang}.
-     - **"translate_text"**: The ${targetLang} translation.
-     - **"example_using"**: A sample sentence demonstrating the word/phrase in a real-world context related to the provided topic, in ${sourceLang}.
-      - **"translate_example"**: The ${targetLang} translation of the example sentence.
-     - **"category"**: A short, meaningful category in the ${targetLang} language that represents the key theme of the flashcard (e.g., if learning Polish: "Rozmowa kwalifikacyjna", if learning Spanish: "Entrevista de trabajo", if learning Italian: "Colloquio di lavoro", all instead of the English "Job Interview"). A single, consistent category that applies to **all** generated flashcards.
-  3. **Ensure the following:**
-     - Words and phrases are **unique** (no repetitions).
-     - Example sentences are **diverse** and **practical for real-world use**.
-     - Avoid **overly simple, obvious, or off-topic words** that do not directly aid in learning the topic effectively.
-  4. **The response must be in strict JSON format, following this exact structure, with no additional text or comments:**
+Required JSON format:
+{
+  "flashcards": [
+    {
+      "origin_text": "word in ${sourceLang}",
+      "translate_text": "translation in ${targetLang}",
+      "example_using": "example sentence in ${sourceLang}",
+      "translate_example": "example translation in ${targetLang}",
+      "category": "category name in ${targetLang}",
+      "translate_category": "category name in ${sourceLang}"
+    }
+  ]
+}
 
-  \`\`\`json
-  {
-    "flashcards": [
-      {
-        "origin_text": "example word",
-        "translate_text": "example translation",
-        "example_using": "example sentence using the word in context",
-        "translate_example": "example translation of the sentence (example_using)",
-        "category": "example category"
-      }
-    ]
-  }
-  \`\`\`
+Rules:
+- All flashcards must have the same category
+- Category should be in ${targetLang} (learning language)
+- translate_category should be in ${sourceLang} (interface language)
+- Words must be relevant to the topic
+- No repetitions
+- Examples must be practical
 
-### **Category Guidelines:**
-  - The category should be **concise and descriptive**, summarizing the primary theme of the flashcards.
-  - **All generated flashcards must belong to the same category** (no mixing within one response).
-  - **If the user specifies an EXACT category name in their request, use that EXACT name without any modifications.**
-  - Choose a category that accurately reflects the user's input. 
-  - If the user's input is broad (e.g., "travel"), use a meaningful subcategory such as "Airport", "Hotel Booking", or "Local Transport".
-  - If uncertain, choose the most general but meaningful category.
-  - **CRITICAL: When generating additional flashcards for an existing category, preserve the category name exactly as specified.**
-
-  ### **Reference Previous Examples:**
-  The user has previously requested flashcards for similar topics. Here are some examples:
-  ${
-    previousExamples.length > 0
-      ? previousExamples.map(example => `
-        **User Request:** "${example.messages[1].content}"
-        **Response Structure:**
-        \`\`\`json
-        {
-          "flashcards": ${JSON.stringify(example.response, null, 2)}
-        }
-        \`\`\`
-        `).join('\n\n')
-      : "No previous examples available."
-  }
-  
-  ### **Incorrect Example (for the topic "Job Interview")**
-  - Words should help in **handling** the interview (e.g., "experience", "qualifications"), not **general terms** (e.g., "business attire"), because probably such a term may not be used in a conversation with the HR department that will conduct the recruitment. The HR department will want information from us about ourselves, our professional experience, plans for the future, etc. 
-  \`\`\`json
-  {
-    "flashcards": [
-      {
-        "origin_text": "business attire",
-        "translate_text": "ubiór biznesowy",
-        "example_using": "You have a nice business attire for the interview.",
-        "translate_example": "Masz ładny ubiór biznesowy na rozmowę kwalifikacyjną.",
-        "category": "Incorrect"
-      }
-    ]
-  }
-  \`\`\`
-  
-  ### **Correct Example (for the topic "Car Rental")**
-  - Words should focus on **terms relevant to renting a car**, such as contract details, insurance, and rental policies.
-  \`\`\`json
-  {
-    "flashcards": [
-      {
-        "origin_text": "rental agreement",
-        "translate_text": "umowa wynajmu",
-        "example_using": "Before driving away, make sure to read the rental agreement carefully.",
-        "translate_example": "Przed odjazdem upewnij się, że dokładnie przeczytałeś umowę wynajmu.",
-        "category": "Car Rental"
-      }
-    ]
-  }
-  \`\`\`
-  
-  ### **Incorrect Example (for the topic "Business Meeting")**
-  \`\`\`json
-  {
-    "flashcards": [
-      {
-        "origin_text": "business etiquette",
-        "translate_text": "etykieta biznesowa",
-        "example_using": "Proper business etiquette helps maintain professional relationships.",
-        "translate_example": "Prawidłowa etykieta biznesowa pomaga utrzymać profesjonalne relacje.",
-        "category": "Incorrect"
-      }
-    ]
-  }
-  \`\`\`
+Example:
+For topic "restaurant" when learning Polish:
+- category: "Restauracja" (Polish)
+- translate_category: "Restaurant" (English)
   `;
 };

--- a/src/types/flashcard.ts
+++ b/src/types/flashcard.ts
@@ -4,6 +4,7 @@ export interface ImportableFlashcard {
   example_using: string;
   translate_example: string;
   category: string;
+  translate_category: string;
   sourceLanguage: string;
   targetLanguage: string;
   difficultyLevel: string;


### PR DESCRIPTION
- Change translate_category from optional to required in all interfaces
- Update Zod schema to require translate_category field
- OpenAI must now always provide category translation
- Add fallback mechanism for legacy records in repository
- Update prompts to clearly require translation
- Optimize sidebar performance with categoryInfoMap
- Fix all English comments consistency
- Ensure type safety across all components

Breaking change: OpenAI responses must include translate_category