### PR TITLE
Fix social media meta tags for LinkedIn sharing

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -17,6 +17,42 @@ export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
 }
 
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://languito.eu';
+  
+  return {
+    metadataBase: new URL(siteUrl),
+    openGraph: {
+      title: 'Languito - Language Learning with AI Flashcards',
+      description: 'Transform your language learning with AI-generated flashcards tailored to your specific needs.',
+      url: siteUrl,
+      siteName: 'Languito',
+      images: [
+        {
+          url: '/landing.png', // Relative to metadataBase
+          width: 1200,
+          height: 630,
+          alt: 'Languito - AI-powered language learning platform',
+          type: 'image/png',
+        },
+      ],
+      locale: locale,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'Languito - Language Learning with AI Flashcards',
+      description: 'Transform your language learning with AI-generated flashcards tailored to your specific needs.',
+      images: ['/landing.png'], // Relative to metadataBase
+    },
+  };
+}
+
 export default async function LocaleLayout({
   children,
   params
@@ -46,6 +82,7 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale}>
+
       <body className="relative isolate overflow-x-hidden">
         <ErrorBoundary>
           <LoadingErrorProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,51 @@
 import './globals.css';
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://languito.eu';
+
 export const metadata = {
   title: 'Languito - Language Learning with AI Flashcards',
   description: 'Learn any language with AI-generated flashcards tailored to your needs',
+  keywords: 'language learning, AI flashcards, vocabulary, language education, spaced repetition',
+  authors: [{ name: 'Languito Team' }],
+  creator: 'Languito',
+  openGraph: {
+    title: 'Languito - Language Learning with AI Flashcards',
+    description: 'Transform your language learning with AI-generated flashcards tailored to your specific needs. Master vocabulary faster with our intelligent spaced repetition system.',
+    url: siteUrl,
+    siteName: 'Languito',
+    images: [
+      {
+        url: `${siteUrl}/landing.png`,
+        width: 1200,
+        height: 630,
+        alt: 'Languito - AI-powered language learning platform with flashcards',
+        type: 'image/png',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Languito - Language Learning with AI Flashcards',
+    description: 'Transform your language learning with AI-generated flashcards tailored to your specific needs.',
+    images: [`${siteUrl}/landing.png`],
+    creator: '@languito_app',
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+  verification: {
+    google: 'your-google-verification-code', 
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
- Add generateMetadata function to locale layout with metadataBase
- Use environment variables for flexible site URL configuration
- Implement proper Open Graph and Twitter Card meta tags
- Set correct image dimensions (1200x630) for LinkedIn compatibility
- Add metadataBase to automatically resolve relative image paths
- Configure locale-specific meta tags for better social sharing